### PR TITLE
[UPDATE] health-status path will not be blocked from any host

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,6 +1,7 @@
 example_id                                    | status | run_time        |
 --------------------------------------------- | ------ | --------------- |
-./spec/app_health_status_routing_spec.rb[1:1] | passed | 0.03629 seconds |
-./spec/app_health_status_routing_spec.rb[1:2] | passed | 0.00012 seconds |
-./spec/app_health_status_spec.rb[1:1]         | passed | 0.00053 seconds |
-./spec/app_health_status_spec.rb[1:2]         | passed | 0.00006 seconds |
+./spec/app_health_status_routing_spec.rb[1:1] | passed | 0.03578 seconds |
+./spec/app_health_status_routing_spec.rb[1:2] | passed | 0.00009 seconds |
+./spec/app_health_status_routing_spec.rb[1:3] | passed | 0.00005 seconds |
+./spec/app_health_status_spec.rb[1:1]         | passed | 0.00046 seconds |
+./spec/app_health_status_spec.rb[1:2]         | passed | 0.00005 seconds |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    app_health_status (0.2.1)
+    app_health_status (0.2.2)
       rack
 
 GEM
@@ -50,4 +50,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.0.2
+   2.3.14

--- a/lib/app_health_status/railtie.rb
+++ b/lib/app_health_status/railtie.rb
@@ -5,6 +5,12 @@ module AppHealthStatus
   class Railtie < ::Rails::Railtie
     initializer 'app_health_status.configure_rails_initialization' do
       Rails.application.middleware.use Rack::AppHealthStatusMiddleware
+
+      if Rails.application.config.respond_to?(:host_authorization) && Rails.application.config.host_authorization[:exclude].nil?
+        Rails.application.config.host_authorization = {
+          exclude: ->(request) { request.path.include?(AppHealthStatus.configuration.path) }
+        }
+      end
     end
   end
 end

--- a/lib/app_health_status/version.rb
+++ b/lib/app_health_status/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppHealthStatus
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/app_health_status_routing_spec.rb
+++ b/spec/app_health_status_routing_spec.rb
@@ -1,25 +1,35 @@
 RSpec.describe Rack::AppHealthStatusMiddleware do
-  let(:app) { ->(env) { [404, env, "app"] } }
+  let(:app) { ->(env) { [env['HOST'] && env['HOST'] != env['SERVER_NAME'] ? 403 : 404, env, 'app'] } }
   let(:middleware) do
     Rack::AppHealthStatusMiddleware.new(app)
   end
 
   it 'should return 200 when path matches' do
-    code, env = middleware.call env_for('https://www.pacexam.com/app-health-status')
+    code, env = middleware.call env_for('https://www.elitmus.com/app-health-status')
     expect(code).to eq(200)
     user_defined_path = 'some-random-path'
     AppHealthStatus.configuration.path = user_defined_path
-    code, env = middleware.call env_for("https://www.pacexam.com/#{user_defined_path}")
+    code, env = middleware.call env_for("https://www.elitmus.com/#{user_defined_path}")
     expect(code).to eq(200)
     AppHealthStatus.reset
   end
 
   it 'should not interfere when path does matches' do
-    code, env = middleware.call env_for('https://www.pacexam.com/some-random-path')
+    code, env = middleware.call env_for('https://www.elitmus.com/some-random-path')
     expect(code).to eq(404)
   end
 
-  def env_for url
-    Rack::MockRequest.env_for(url)
+  it 'should give 403 when host is differnt and path is not whitelisted' do
+    code, env = middleware.call env_for('https://www.elitmus.com/some-random-path', {
+      'HTTP_X_FORWARDED_HOST' => '//randomhost.com',
+      'HOST' => 'www.randomhost.com',
+      'action_dispatch.show_detailed_exceptions' => true
+    })
+    
+    expect(code).to eq(403)
+  end
+
+  def env_for url, opts = {}
+    Rack::MockRequest.env_for(url, opts)
   end
 end


### PR DESCRIPTION
**Problem**
    Need to allow all the hosts which access `/app-health-status` path.
  

**Solution**
1. Whitelisted the host using host_authorization option.
2. This will only be used if host_authorization is not set by client.
3. Added relevant test cases.

